### PR TITLE
Error Returned if Pandoras Box NOT Connected - prevents NODE crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,10 +366,14 @@ PBAuto.prototype.send = function(t, e, r){
                     	}
 	                    e(t);
                 	}
-                );
+				);
         	}
     	}
     	);
+		req.on('error', (err) => {
+			console.error(`problem with request: ${err.message}`);
+			e({ok: false, message:err.message});
+		});
     req.write(Base64.encode(t.getRawBytes()));
     req.end();
 }


### PR DESCRIPTION
Added error handling to end of file in the case that Pandoras Box is not connected to the Node Server.
Now this will return an error instead of crashing Node if Pandoras Box is not connected and a request is sent to Pandoras Box.
